### PR TITLE
Ch7569: Recalculate Y-axis when providers are disabled

### DIFF
--- a/src/modules/charts/components/Chart.js
+++ b/src/modules/charts/components/Chart.js
@@ -32,7 +32,6 @@ function Chart({
   isMobile,
   yAxisTicks,
   annotations,
-  activeLines,
   onFinishLoad,
 }) {
   const { colors, tones } = useTheme()
@@ -132,14 +131,8 @@ function Chart({
               stroke={tones[key].medium}
               fillOpacity={1}
               fill={`url(#${key}-fill)`}
-              dot={<CustomDot belongsToActiveLine={!!activeLines[key]} />}
-              activeDot={
-                <CustomDot
-                  active={true}
-                  belongsToActiveLine={!!activeLines[key]}
-                />
-              }
-              style={{ display: !activeLines[key] ? `none` : undefined }}
+              dot={<CustomDot />}
+              activeDot={<CustomDot active={true} />}
               animationDuration={isRendered ? 0 : 1000}
               strokeDasharray={strokeDasharray}
               className={`main-chart-area`}

--- a/src/modules/charts/components/CustomDot.js
+++ b/src/modules/charts/components/CustomDot.js
@@ -3,7 +3,7 @@ import { useTheme } from "@modules/ui/components/ThemeProvider"
 import { DetailsChartDimensions } from "../constants"
 
 function CustomDot(prop) {
-  const { cx, cy, dataKey, active = false, belongsToActiveLine } = prop
+  const { cx, cy, dataKey, active = false } = prop
 
   if (!cx || !cy) {
     return null
@@ -23,7 +23,6 @@ function CustomDot(prop) {
       width={ActiveDotDiam}
       height={ActiveDotDiam}
       viewBox={`0 0 ${ActiveDotDiam} ${ActiveDotDiam}`}
-      css={{ display: !belongsToActiveLine ? `none` : undefined }}
     >
       {active && (
         <circle

--- a/src/modules/charts/components/CustomLegend.js
+++ b/src/modules/charts/components/CustomLegend.js
@@ -5,7 +5,7 @@ import { ToggleCheckbox } from "gatsby-interface"
 import LinePreview from "./LinePreview"
 import { useTheme } from "@modules/ui/components/ThemeProvider"
 
-function CustomLegend({ onClick, activeLines }) {
+function CustomLegend({ onClick, chartActiveLines }) {
   const { LegendMinHeight, YAxisWidth, VerticalGap } = DetailsChartDimensions
   const { tones } = useTheme()
 
@@ -25,8 +25,8 @@ function CustomLegend({ onClick, activeLines }) {
         },
       })}
     >
-      {Object.keys(activeLines).map(key => {
-        const isActive = activeLines[key]
+      {Object.keys(chartActiveLines).map(key => {
+        const isActive = chartActiveLines[key]
         const displayedAs = BuildType[key].displayedAs
 
         /*

--- a/src/modules/charts/components/DetailsChart.helpers.js
+++ b/src/modules/charts/components/DetailsChart.helpers.js
@@ -56,7 +56,6 @@ export function yAxisTickFormater(value) {
 }
 
 export function getYAxisTicks(data) {
-  //  console.log({ data })
   const maxValue = data.reduce((result, row) => {
     const maxItemValue = Object.keys(row).reduce((rowResult, key) => {
       return typeof row[key] === "number" && row[key] > rowResult

--- a/src/modules/charts/components/DetailsChart.helpers.js
+++ b/src/modules/charts/components/DetailsChart.helpers.js
@@ -3,8 +3,6 @@ import formatDuration from "../utils/formatDuration"
 import { DetailsChartDimensions } from "../constants"
 
 const { ActiveDotRadius } = DetailsChartDimensions
-const SECONDS_IN_MINUTE = 60
-const MINUTES_IN_HOUR = 60
 
 export function filteredDataInitialStartIndex({
   data,
@@ -55,8 +53,8 @@ export function yAxisTickFormater(value) {
     .join(" ")
 }
 
-export function getYAxisTicks(data) {
-  const maxValue = data.reduce((result, row) => {
+function getMaxValue(data) {
+  return data.reduce((result, row) => {
     const maxItemValue = Object.keys(row).reduce((rowResult, key) => {
       return typeof row[key] === "number" && row[key] > rowResult
         ? row[key]
@@ -65,56 +63,72 @@ export function getYAxisTicks(data) {
 
     return maxItemValue > result ? maxItemValue : result
   }, 0)
+}
 
-  const maxTickInMinutes = Math.ceil(maxValue / SECONDS_IN_MINUTE)
-  let maxTickInHours
-  let maxTickInSeconds
+function getRoundedMaxValue(maxValue) {
+  const SECONDS_IN_MINUTE = 60
+  const MINUTES_IN_HOUR = 60
+  const MIN_ROUNDING = 10
 
-  if (maxTickInMinutes >= MINUTES_IN_HOUR) {
-    maxTickInHours = Math.ceil(maxTickInMinutes / MINUTES_IN_HOUR)
-    maxTickInSeconds = maxTickInHours * MINUTES_IN_HOUR * SECONDS_IN_MINUTE
+  if (maxValue < SECONDS_IN_MINUTE) {
+    return {
+      roundedMaxValue: Math.ceil(maxValue / MIN_ROUNDING) * MIN_ROUNDING,
+      multiplier: 1,
+    }
+  } else if (maxValue < SECONDS_IN_MINUTE * MINUTES_IN_HOUR) {
+    return {
+      roundedMaxValue: Math.ceil(maxValue / SECONDS_IN_MINUTE),
+      multiplier: SECONDS_IN_MINUTE,
+    }
   } else {
-    maxTickInSeconds = maxTickInMinutes * SECONDS_IN_MINUTE
+    return {
+      roundedMaxValue: Math.ceil(
+        maxValue / (SECONDS_IN_MINUTE * MINUTES_IN_HOUR)
+      ),
+      multiplier: SECONDS_IN_MINUTE * MINUTES_IN_HOUR,
+    }
   }
+}
 
-  const maxTipNumberValue = maxTickInHours ? maxTickInHours : maxTickInMinutes
-  const multiplier = maxTickInHours
-    ? MINUTES_IN_HOUR * SECONDS_IN_MINUTE
-    : SECONDS_IN_MINUTE
+export function getYAxisTicks(data) {
+  const maxValue = getMaxValue(data)
+  const { roundedMaxValue, multiplier } = getRoundedMaxValue(maxValue)
+  const maxTick = roundedMaxValue * multiplier
 
   // depending on max tick value we render different amount of ticks,
   // the goal is that we render ticks with integer value in one unit
   // for example 15s, 45s, 1m, 3m, 45m, 1h, 3h,
   // but never 1m 35s, or 1h 25m
   // this way wy maintain proper spacing between yAxis label and its ticks' labels
-  if (maxTipNumberValue === 1) {
+
+  if (roundedMaxValue === 1) {
     const secondTick = 0.25 * multiplier
     const thirdTick = 0.5 * multiplier
     const fourthTick = 0.75 * multiplier
 
-    return [0, secondTick, thirdTick, fourthTick, maxTickInSeconds]
-  } else if (maxTipNumberValue === 2) {
+    return [0, secondTick, thirdTick, fourthTick, maxTick]
+  } else if (roundedMaxValue === 2) {
     const secondTick = 1 * multiplier
 
-    return [0, secondTick, maxTickInSeconds]
-  } else if (maxTipNumberValue === 3) {
+    return [0, secondTick, maxTick]
+  } else if (roundedMaxValue === 3) {
     const secondTick = 1 * multiplier
     const thirdTick = 2 * multiplier
 
-    return [0, secondTick, thirdTick, maxTickInSeconds]
-  } else if (maxTipNumberValue % 2 !== 0) {
-    const secondTick = Math.floor(maxTipNumberValue * 0.2) * multiplier
-    const thirdTick = Math.floor(maxTipNumberValue * 0.4) * multiplier
-    const fourthTick = Math.floor(maxTipNumberValue * 0.6) * multiplier
-    const fifthTick = Math.floor(maxTipNumberValue * 0.8) * multiplier
+    return [0, secondTick, thirdTick, maxTick]
+  } else if (roundedMaxValue % 2 !== 0) {
+    const secondTick = Math.floor(roundedMaxValue * 0.2) * multiplier
+    const thirdTick = Math.floor(roundedMaxValue * 0.4) * multiplier
+    const fourthTick = Math.floor(roundedMaxValue * 0.6) * multiplier
+    const fifthTick = Math.floor(roundedMaxValue * 0.8) * multiplier
 
-    return [0, secondTick, thirdTick, fourthTick, fifthTick, maxTickInSeconds]
+    return [0, secondTick, thirdTick, fourthTick, fifthTick, maxTick]
   } else {
-    const secondTick = Math.floor(maxTipNumberValue * 0.25) * multiplier
-    const thirdTick = Math.floor(maxTipNumberValue * 0.5) * multiplier
-    const fourthTick = Math.ceil(maxTipNumberValue * 0.75) * multiplier
+    const secondTick = Math.floor(roundedMaxValue * 0.25) * multiplier
+    const thirdTick = Math.floor(roundedMaxValue * 0.5) * multiplier
+    const fourthTick = Math.ceil(roundedMaxValue * 0.75) * multiplier
 
-    return [0, secondTick, thirdTick, fourthTick, maxTickInSeconds]
+    return [0, secondTick, thirdTick, fourthTick, maxTick]
   }
 }
 

--- a/src/modules/charts/components/DetailsChart.js
+++ b/src/modules/charts/components/DetailsChart.js
@@ -36,11 +36,12 @@ function DetailsChart({
   initialDataRangeMobile = ChartDefaultProps.InitialDataScopeMobile,
   annotations = [],
   setChartIsMounted,
+  chartActiveLines,
+  setChartActiveLines,
   ...rest
 }) {
   const { mediaQueries } = useTheme()
   const isMobile = !useMatchMedia(mediaQueries.desktop)
-
   const [filteredData, setFilteredData] = React.useState()
   const [filteredDataStartIndex, setFilteredDataStartIndex] = React.useState(
     filteredDataInitialStartIndex({
@@ -58,6 +59,7 @@ function DetailsChart({
     isMobile,
     filteredDataStartIndex,
     filteredDataEndIndex,
+    data,
   ])
 
   function filterDataCallback() {
@@ -72,12 +74,6 @@ function DetailsChart({
     )
   }
 
-  const [activeLines, setActiveLines] = React.useState({
-    COLD_START: true,
-    DATA_UPDATE: true,
-    WARM_START: true,
-  })
-
   const yAxisTicks = getYAxisTicks(data)
 
   if (!filteredData) {
@@ -85,7 +81,10 @@ function DetailsChart({
   }
 
   const toggleChartLine = dataKey => {
-    setActiveLines({ ...activeLines, [dataKey]: !activeLines[dataKey] })
+    setChartActiveLines({
+      ...chartActiveLines,
+      [dataKey]: !chartActiveLines[dataKey],
+    })
   }
 
   const updateDataRange = ({ startIndex, endIndex }) => {
@@ -116,7 +115,6 @@ function DetailsChart({
             isMobile={isMobile}
             yAxisTicks={yAxisTicks}
             annotations={annotations}
-            activeLines={activeLines}
             onFinishLoad={setChartIsMounted}
           />
         </div>
@@ -132,7 +130,6 @@ function DetailsChart({
           <LazyRangeControllerDesktop
             data={data}
             isMobile={isMobile}
-            activeLines={activeLines}
             filteredDataStartIndex={filteredDataStartIndex}
             filteredDataEndIndex={filteredDataEndIndex}
             updateDataRange={updateDataRange}
@@ -140,7 +137,10 @@ function DetailsChart({
           />
         </div>
       )}
-      <CustomLegend activeLines={activeLines} onClick={toggleChartLine} />
+      <CustomLegend
+        chartActiveLines={chartActiveLines}
+        onClick={toggleChartLine}
+      />
     </div>
   )
 }

--- a/src/modules/charts/components/RangeControllerDesktop.js
+++ b/src/modules/charts/components/RangeControllerDesktop.js
@@ -24,7 +24,6 @@ const {
 
 function RangeControllerDesktop({
   data,
-  activeLines,
   yAxisTicks,
   isMobile,
   filteredDataStartIndex,
@@ -73,7 +72,6 @@ function RangeControllerDesktop({
               stroke={tones[key].medium}
               fillOpacity={1}
               fill={`url(#${key}-fill)`}
-              style={{ display: !activeLines[key] ? `none` : undefined }}
               isAnimationActive={false}
             />
           ))}

--- a/src/modules/siteDetails/components/SiteDetailsPage.helpers.js
+++ b/src/modules/siteDetails/components/SiteDetailsPage.helpers.js
@@ -1,6 +1,6 @@
 import format from "date-fns/format"
 
-export function formatDataForChart({ benchmarks }) {
+export function formatDataForChart({ benchmarks, chartActiveLines }) {
   const graphDataByCreatedAt = {}
 
   benchmarks.forEach(({ createdAt, buildType, buildTimes }) => {
@@ -17,7 +17,7 @@ export function formatDataForChart({ benchmarks }) {
       }
     }
 
-    if (timeInMs) {
+    if (timeInMs && chartActiveLines[buildType]) {
       graphDataByCreatedAt[formatedCreatedAt][buildType] = Math.floor(
         timeInMs / 1000
       )
@@ -34,5 +34,5 @@ export function formatDataForChart({ benchmarks }) {
     (a, b) => new Date(b.createdAt) + new Date(a.createdAt)
   )
 
-  return { graphData }
+  return graphData
 }

--- a/src/modules/siteDetails/components/SiteDetailsPage.js
+++ b/src/modules/siteDetails/components/SiteDetailsPage.js
@@ -23,6 +23,12 @@ const { YAxisWidth, ChartWithControlsHeight } = DetailsChartDimensions
 const SiteDetailsPage = ({ data, pageContext }) => {
   const [chartIsMounted, setChartIsMounted] = React.useState(false)
   const { activeBenchmarks } = pageContext
+  const [graphData, setGraphData] = React.useState()
+  const [chartActiveLines, setChartActiveLines] = React.useState({
+    DATA_UPDATE: true,
+    WARM_START: true,
+    COLD_START: true,
+  })
 
   React.useEffect(() => {
     setChartIsMounted(true)
@@ -52,12 +58,21 @@ const SiteDetailsPage = ({ data, pageContext }) => {
 
   const isArtificiallySlow = !!ArtificiallySlowContentSources[contentSource]
 
-  const { graphData } = formatDataForChart({
-    benchmarks,
-    pageCount,
-  })
+  React.useEffect(() => {
+    const graphData = formatDataForChart({
+      benchmarks,
+      pageCount,
+      chartActiveLines,
+    })
+
+    setGraphData(graphData)
+  }, [benchmarks, pageCount, chartActiveLines])
 
   const { displayedAs: contentSourceTitle } = ContentSource[contentSource]
+
+  if (!graphData) {
+    return null
+  }
 
   return (
     <MaxWidthWrapper
@@ -127,6 +142,8 @@ const SiteDetailsPage = ({ data, pageContext }) => {
           data={graphData}
           annotations={graphAnnotations}
           setChartIsMounted={setChartIsMounted}
+          chartActiveLines={chartActiveLines}
+          setChartActiveLines={setChartActiveLines}
         />
       </section>
 


### PR DESCRIPTION
# Purpose 

https://app.clubhouse.io/gatsbyjs/story/7569/recalculate-y-axis-when-providers-are-disabled

Changes:
- trigger `formatDataForChart` every time the the Legend toggle changes value
- update `formatDataForChart`, with this changes the minimal max tick value on Yaxis is 10s (now it is 1min)

![Gatsby and Contentful Build Benchmarks _ Will It Build_](https://user-images.githubusercontent.com/32480082/83444977-7d9afb00-a44c-11ea-8f90-ee268263ff5a.gif)
